### PR TITLE
Update dependency installation command in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 24.12.0
 
       - name: Install deps
-        run: npm ci
+        run: npm i
 
       - name: Generate docs
         run: npm run docs


### PR DESCRIPTION
Changed the dependency installation command from 'npm ci' to 'npm i'.